### PR TITLE
add .yarnrc.yml

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+npmRegistryServer: "https://jfrog.ais.acquia.io/artifactory/api/npm/widen-npm-virtual/"


### PR DESCRIPTION
Adding `
npmRegistryServer: "https://jfrog.ais.acquia.io/artifactory/api/npm/widen-npm-virtual/"` should be enough to add the correct credentials when publishing